### PR TITLE
chore: Remove Python 3.11 upper bound

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: TestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find_namespace:
 python_requires = >=3.9,!=3.9.7
 
 install_requires =
-    pyquil>=2.25, <=3.3
+    pyquil~=4.0
     orquestra-quantum
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 
 install_requires =
     pyquil>=2.25, <=3.3

--- a/tests/orquestra/integrations/forest/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/forest/circuit_conversions_test.py
@@ -135,9 +135,22 @@ def pyquil_u3_definition():
     )
 
 
+def pyquil_sqrt_x_definition():
+    return pyquil.quil.DefGate(
+        "SQRT-X",
+        np.array(
+            [
+                [0.5 + 0.5j, 0.5 - 0.5j],
+                [0.5 - 0.5j, 0.5 + 0.5j],
+            ]
+        ),
+    )
+
+
 PYQUIL_XX = pyquil_xx_definition()
 PYQUIL_RH = pyquil_rh_definition()
 PYQUIL_U3 = pyquil_u3_definition()
+PYQUIL_SQRT_X = pyquil_sqrt_x_definition()
 
 
 EQUIVALENT_CIRCUITS = [
@@ -196,14 +209,8 @@ EQUIVALENT_CIRCUITS = [
         _circuit.Circuit(
             [SQRT_X_DEF()(3)],
         ),
-        pyquil.Program([("SQRT-X", 3)]).defgate(
-            "SQRT-X",
-            np.array(
-                [
-                    [0.5 + 0.5j, 0.5 - 0.5j],
-                    [0.5 - 0.5j, 0.5 + 0.5j],
-                ]
-            ),
+        pyquil.Program(
+            [PYQUIL_SQRT_X, PYQUIL_SQRT_X.get_constructor()(3)],
         ),
     ),
     (


### PR DESCRIPTION
## Description

In order to allow Python versions newer than 3.10 we need to remove the upper bound.

This PR:
- allows Orquestra Forest to work on 3.11 and later
- Updates pyquil
- Updates SQRT-X test to match the other def gate tests


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
